### PR TITLE
Formulaire alternatif pour choisir un mode de livraison

### DIFF
--- a/formulaires/adresser_commande.html
+++ b/formulaires/adresser_commande.html
@@ -141,23 +141,19 @@
 
 			</B_modechoisi>
 				<B_choixmodes>
-					<div class="liste long">
+					<div class="liste long livraisonmodes">
 					<h3><span><:livraison:titre_votre_mode_de_livraison:></span></h3>
 						<ul class="liste-items">
 						<BOUCLE_choixmodes(POUR){tableau #ENV{_choix_livraisonmode}}{si #GET{modif}|non}>
 							<li class="item">
-								<div class="entry">
-									<BOUCLE_modes(LIVRAISONMODES){id_livraisonmode IN #VALEUR{id}|explode{','}}{par num titre,titre}>
-									<strong class="entry-title">[(#LOGO_LIVRAISONMODE|image_reduire{-1}) ][(#TITRE)][ (#_choixmodes:VALEUR{decomposition/#ID_LIVRAISONMODE/prix_ttc}|affiche_monnaie)]</strong>
-									[<div class="entry-content">(#DESCRIPTIF)</div>]
-									</BOUCLE_modes>
-									<div class="postmeta p">
-										<button type="submit" class="btn btn-primary" name="choixmode[#VALEUR{id}]" value="#VALEUR{id}">
-											#SET{prix,#VALEUR{prix_ttc}|affiche_monnaie}
-											<:livraison:bouton_choix_mode{mode=#VALEUR{titre},prix=#GET{prix}}:>
-										</button>
-									</div>
-								</div>
+								<INCLURE{fond=formulaires/inc-choisir-livraisonmode,
+									id=#VALEUR{id},
+									prix_ht=#VALEUR{prix_ht},
+									prix=#VALEUR{prix_ttc},
+									titre=#VALEUR{titre},
+									decomposition=#VALEUR{decomposition},
+									env}
+								>
 							</li>
 						</BOUCLE_choixmodes>
 						</ul>

--- a/formulaires/choisir_livraisonmode_commande.html
+++ b/formulaires/choisir_livraisonmode_commande.html
@@ -24,24 +24,15 @@
 			<h3><span><:livraison:titre_votre_mode_de_livraison:></span></h3>
 			<ul class="liste-items">
 			<BOUCLE_choix_modes(POUR) {tableau #ENV{_choix_livraisonmode}}>
-			#SET{prix,#VALEUR{prix_ttc}|affiche_monnaie}
 			<li class="item">
-				<div class="entry">
-					<BOUCLE_modes(LIVRAISONMODES) {id_livraisonmode IN #VALEUR{id}|explode{','}} {par num titre,titre}>
-					<strong class="entry-title">
-						[(#LOGO_LIVRAISONMODE|image_reduire{-1})]
-						<span>[(#TITRE)][ (#_choix_modes:VALEUR{decomposition/#ID_LIVRAISONMODE/prix_ttc}|affiche_monnaie)]</span>
-					</strong>
-					[<div class="entry-content">
-						(#DESCRIPTIF)
-					</div>]
-					</BOUCLE_modes>
-					<div class="postmeta p">
-						<button type="submit" class="btn btn-primary" name="choixmode[#VALEUR{id}]" value="#VALEUR{id}">
-							<:livraison:bouton_choix_mode{mode=#VALEUR{titre},prix=#GET{prix}}:>
-						</button>
-					</div>
-				</div>
+				<INCLURE{fond=formulaires/inc-choisir-livraisonmode,
+					id=#VALEUR{id},
+					prix_ht=#VALEUR{prix_ht},
+					prix=#VALEUR{prix_ttc},
+					titre=#VALEUR{titre},
+					decomposition=#VALEUR{decomposition},
+					env}
+				>
 			</li>
 			</BOUCLE_choix_modes>
 			</ul>

--- a/formulaires/choisir_livraisonmode_commande.html
+++ b/formulaires/choisir_livraisonmode_commande.html
@@ -1,0 +1,56 @@
+<div class='formulaire_spip formulaire_editer formulaire_#FORM formulaire_#FORM-#ENV{id_commande,nouveau}'>
+
+	[<p class="reponse_formulaire reponse_formulaire_ok">(#ENV**{message_ok})</p>]
+	[<p class="reponse_formulaire reponse_formulaire_erreur">(#ENV*{message_erreur})</p>]
+
+	<BOUCLE_editable(CONDITION) {si #ENV{editable}}>
+	<form method='post' action='#ENV{action}'><div>
+		#ACTION_FORMULAIRE{#ENV{action}}
+
+		[(#REM) Sans livraison nécessaire, un message + lien pour étape suivante ]
+		<BOUCLE_sans_livraison(CONDITION) {si #ENV{_livraison_necessaire}|non}>
+		<p class="message message_info">Pas de livraison nécessaire</p>
+		<div class="boutons">
+			<a class="btn btn-primary btn-large pull-right"
+				href="#ENV{_url_suite}">
+				[(#ENV{_titre_suite,<:livraison:bouton_suite:>})] <i class="icon-chevron-right icon-white"></i>
+			</a>
+		</div>
+		</BOUCLE_sans_livraison>
+
+		[(#REM) Choix du mode de livraison ]
+		<B_choix_modes>
+		<div class="liste liste_livraisonmodes long">
+			<h3><span><:livraison:titre_votre_mode_de_livraison:></span></h3>
+			<ul class="liste-items">
+			<BOUCLE_choix_modes(POUR) {tableau #ENV{_choix_livraisonmode}}>
+			#SET{prix,#VALEUR{prix_ttc}|affiche_monnaie}
+			<li class="item">
+				<div class="entry">
+					<BOUCLE_modes(LIVRAISONMODES) {id_livraisonmode IN #VALEUR{id}|explode{','}} {par num titre,titre}>
+					<strong class="entry-title">
+						[(#LOGO_LIVRAISONMODE|image_reduire{-1})]
+						<span>[(#TITRE)][ (#_choix_modes:VALEUR{decomposition/#ID_LIVRAISONMODE/prix_ttc}|affiche_monnaie)]</span>
+					</strong>
+					[<div class="entry-content">
+						(#DESCRIPTIF)
+					</div>]
+					</BOUCLE_modes>
+					<div class="postmeta p">
+						<button type="submit" class="btn btn-primary" name="choixmode[#VALEUR{id}]" value="#VALEUR{id}">
+							<:livraison:bouton_choix_mode{mode=#VALEUR{titre},prix=#GET{prix}}:>
+						</button>
+					</div>
+				</div>
+			</li>
+			</BOUCLE_choix_modes>
+			</ul>
+		</div>
+		</B_choix_modes>
+		<//B_sans_livraison>
+
+		[(#REM) ajouter les saisies supplementaires : extra et autre, a cet endroit ]
+		<!--extra-->
+	</div></form>
+	</BOUCLE_editable>
+</div>

--- a/formulaires/choisir_livraisonmode_commande.html
+++ b/formulaires/choisir_livraisonmode_commande.html
@@ -20,7 +20,7 @@
 
 		[(#REM) Choix du mode de livraison ]
 		<B_choix_modes>
-		<div class="liste liste_livraisonmodes long">
+		<div class="liste livraisonmodes long">
 			<h3><span><:livraison:titre_votre_mode_de_livraison:></span></h3>
 			<ul class="liste-items">
 			<BOUCLE_choix_modes(POUR) {tableau #ENV{_choix_livraisonmode}}>

--- a/formulaires/choisir_livraisonmode_commande.php
+++ b/formulaires/choisir_livraisonmode_commande.php
@@ -43,10 +43,6 @@ function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $
 	include_spip('inc/livraison');
 
 	// Infos de livraison pour la commande : pays et code postal.
-	// Pour l'instant c'est à passer dans les options.
-	// TODO : faire appel à une fonction générique mutualisée avec le formulaire dans adresser_commande ?
-	// Complément à renseigner_adresse_auteur() → renseigner_adresse_commande() ?
-	// Ou alors encore plus générique : renseigner_adresse_objet() ?
 	$code_pays = (!empty($options['pays']) ? $options['pays'] : null);
 	$code_postal = (!empty($options['code_postal']) ? $options['code_postal'] : null);
 	if (!$code_pays or !$code_postal) {

--- a/formulaires/choisir_livraisonmode_commande.php
+++ b/formulaires/choisir_livraisonmode_commande.php
@@ -30,7 +30,7 @@ if (!defined('_ECRIRE_INC_VERSION')) {
  *     - titre_suite : intitulé du bouton pour continuer
  * @return void
  */
-function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $redirect = '', $options = array()){
+function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $redirect = '', $options = array()) {
 
 	// Il faut avoir une commande en cours
 	if (
@@ -42,16 +42,30 @@ function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $
 
 	include_spip('inc/livraison');
 
-	// Infos de livraison pour la commande : pays et code postal.
-	$code_pays = (!empty($options['pays']) ? $options['pays'] : null);
-	$code_postal = (!empty($options['code_postal']) ? $options['code_postal'] : null);
-	if (!$code_pays or !$code_postal) {
+	// Soit on a le pays et le code postal dans les options,
+	// soit on les récupère dans la commande
+	if (
+		!isset($options['pays'])
+		and !isset($options['code_postal'])
+	) {
+		if ($commande['livraison_nom']) {
+			$pays        = $commande['livraison_adresse_pays'];
+			$code_postal = $commande['livraison_adresse_cp'];
+		} else {
+			$pays        = $commande['facturation_adresse_pays'];
+			$code_postal = $commande['facturation_adresse_cp'];
+		}
+	} else {
+		$pays        = $options['pays'];
+		$code_postal = $options['code_postal'];
+	}
+	if (!$pays or !$code_postal) {
 		return false;
 	}
 
 	// Trouver les modes de livraison dispos et leurs prix en fonction de l'adresse
 	if ($livraison_necessaire = commande_livraison_necessaire($id_commande)) {
-		$choix_livraisonmode = commande_trouver_livraisons_possibles($id_commande, $code_pays, $code_postal);
+		$choix_livraisonmode = commande_trouver_livraisons_possibles($id_commande, $pays, $code_postal);
 	}
 
 	// Pas de mode de livraison, pas de chocolat
@@ -70,7 +84,7 @@ function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $
 	}
 
 	// Gestion du cache
-	$valeurs['_hash'] = md5(serialize(sql_allfetsel("id_commandes_detail,prix_unitaire_ht,taxe,objet,id_objet,quantite","spip_commandes_details","id_commande=".intval($id_commande))));
+	$valeurs['_hash'] = md5(serialize(sql_allfetsel('id_commandes_detail,prix_unitaire_ht,taxe,objet,id_objet,quantite', 'spip_commandes_details', 'id_commande='.intval($id_commande))));
 
 	return $valeurs;
 }
@@ -87,7 +101,7 @@ function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $
  *     - titre_suite : intitulé du bouton pour continuer
  * @return void
  */
-function formulaires_choisir_livraisonmode_commande_verifier_dist($id_commande, $redirect = '', $options = array()){
+function formulaires_choisir_livraisonmode_commande_verifier_dist($id_commande, $redirect = '', $options = array()) {
 	$erreurs = array();
 	return $erreurs;
 }
@@ -104,7 +118,7 @@ function formulaires_choisir_livraisonmode_commande_verifier_dist($id_commande, 
  *     - titre_suite : intitulé du bouton pour continuer
  * @return void
  */
-function formulaires_choisir_livraisonmode_commande_traiter_dist($id_commande, $redirect = '', $options = array()){
+function formulaires_choisir_livraisonmode_commande_traiter_dist($id_commande, $redirect = '', $options = array()) {
 
 	$res = array();
 

--- a/formulaires/choisir_livraisonmode_commande.php
+++ b/formulaires/choisir_livraisonmode_commande.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Gestion du formulaire pour choisir le mode de livraison d'une commande
+ *
+ * Ce formulaire est une alternative à adresser_commande :
+ * c'est une version simplifiée qui ne traite que le choix du mode de livraison.
+ * Dans ce cas, on est censé avoir défini l'adresse de livraion en amont.
+ *
+ * @plugin     Livraison
+ * @copyright  2015
+ * @author     Cedric
+ * @licence    GNU/GPL
+ * @package    SPIP\Livraison\Formulaires
+ */
+
+// Sécurité
+if (!defined('_ECRIRE_INC_VERSION')) {
+	return;
+}
+
+/**
+ * Charger les valeurs
+ *
+ * @param integer $id_commande
+ * @param string $redirect
+ * @param array $options
+ *     Tableau d'options :
+ *     - code_pays
+ *     - code_postal
+ *     - titre_suite : intitulé du bouton pour continuer
+ * @return void
+ */
+function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $redirect = '', $options = array()){
+
+	// Il faut avoir une commande en cours
+	if (
+		!$id_commande
+		or !$commande = sql_fetsel('*', 'spip_commandes', 'id_commande='.intval($id_commande))
+	) {
+		return false;
+	}
+
+	include_spip('inc/livraison');
+
+	// Infos de livraison pour la commande : pays et code postal.
+	// Pour l'instant c'est à passer dans les options.
+	// TODO : faire appel à une fonction générique mutualisée avec le formulaire dans adresser_commande ?
+	// Complément à renseigner_adresse_auteur() → renseigner_adresse_commande() ?
+	// Ou alors encore plus générique : renseigner_adresse_objet() ?
+	$code_pays = (!empty($options['code_pays']) ? $options['code_pays'] : null);
+	$code_postal = (!empty($options['code_postal']) ? $options['code_postal'] : null);
+	if (!$code_pays or !$code_postal) {
+		return false;
+	}
+
+	// Trouver les modes de livraison dispos et leurs prix en fonction de l'adresse
+	if ($livraison_necessaire = commande_livraison_necessaire($id_commande)) {
+		$choix_livraisonmode = commande_trouver_livraisons_possibles($id_commande, $code_pays, $code_postal);
+	}
+
+	// Pas de mode de livraison, pas de chocolat
+	if (
+		$livraison_necessaire
+		and !$choix_livraisonmode
+	) {
+		$valeurs['message_erreur'] = _T('livraison:erreur_adresse_non_livrable');
+		$valeurs['editable'] = false;
+	} else {
+		$valeurs['id_commande'] = $id_commande;
+		$valeurs['_url_suite'] = $redirect;
+		$valeurs['_titre_suite'] = (!empty($options['titre_suite']) ? $options['titre_suite'] : '');
+		$valeurs['_livraison_necessaire'] = $livraison_necessaire;
+		$valeurs['_choix_livraisonmode'] = $choix_livraisonmode;
+	}
+
+	// Gestion du cache
+	$valeurs['_hash'] = md5(serialize(sql_allfetsel("id_commandes_detail,prix_unitaire_ht,taxe,objet,id_objet,quantite","spip_commandes_details","id_commande=".intval($id_commande))));
+
+	return $valeurs;
+}
+
+/**
+ * Vérifier les valeurs postées
+ *
+ * @param integer $id_commande
+ * @param string $redirect
+ * @param array $options
+ *     Tableau d'options :
+ *     - code_pays
+ *     - code_postal
+ *     - titre_suite : intitulé du bouton pour continuer
+ * @return void
+ */
+function formulaires_choisir_livraisonmode_commande_verifier_dist($id_commande, $redirect = '', $options = array()){
+	$erreurs = array();
+	return $erreurs;
+}
+
+/**
+ * Traitement
+ *
+ * @param integer $id_commande
+ * @param string $redirect
+ * @param array $options
+ *     Tableau d'options :
+ *     - code_pays
+ *     - code_postal
+ *     - titre_suite : intitulé du bouton pour continuer
+ * @return void
+ */
+function formulaires_choisir_livraisonmode_commande_traiter_dist($id_commande, $redirect = '', $options = array()){
+
+	$res = array();
+
+	if ($choixmode = _request('choixmode')) {
+		include_spip('inc/livraison');
+		$choixmode = array_keys($choixmode);
+		$choixmode = reset($choixmode);
+		$fixer = fixer_livraison_commande($id_commande, $choixmode, $options);
+		$res['message_ok'] = _T('livraison:info_livraisonmode_enregistre');
+		$res['editable'] = true;
+	}
+
+	if ($redirect) {
+		$res['redirect'] = $redirect;
+	}
+
+	return $res;
+}

--- a/formulaires/choisir_livraisonmode_commande.php
+++ b/formulaires/choisir_livraisonmode_commande.php
@@ -25,7 +25,7 @@ if (!defined('_ECRIRE_INC_VERSION')) {
  * @param string $redirect
  * @param array $options
  *     Tableau d'options :
- *     - code_pays
+ *     - pays
  *     - code_postal
  *     - titre_suite : intitulé du bouton pour continuer
  * @return void
@@ -47,7 +47,7 @@ function formulaires_choisir_livraisonmode_commande_charger_dist($id_commande, $
 	// TODO : faire appel à une fonction générique mutualisée avec le formulaire dans adresser_commande ?
 	// Complément à renseigner_adresse_auteur() → renseigner_adresse_commande() ?
 	// Ou alors encore plus générique : renseigner_adresse_objet() ?
-	$code_pays = (!empty($options['code_pays']) ? $options['code_pays'] : null);
+	$code_pays = (!empty($options['pays']) ? $options['pays'] : null);
 	$code_postal = (!empty($options['code_postal']) ? $options['code_postal'] : null);
 	if (!$code_pays or !$code_postal) {
 		return false;

--- a/formulaires/choisir_livraisonmode_commande.php
+++ b/formulaires/choisir_livraisonmode_commande.php
@@ -122,6 +122,8 @@ function formulaires_choisir_livraisonmode_commande_traiter_dist($id_commande, $
 	}
 
 	if ($redirect) {
+		include_spip('inc/filtres');
+		$redirect = parametre_url($redirect, 'id_livraisonmode', $choixmode);
 		$res['redirect'] = $redirect;
 	}
 

--- a/formulaires/inc-choisir-livraisonmode.html
+++ b/formulaires/inc-choisir-livraisonmode.html
@@ -1,0 +1,34 @@
+[(#REM)
+
+	Résumé d'un mode de livraison
+
+	Paramètres :
+	**obligatoire
+	*recommandé
+
+	**id : numéros des modes
+	**prix
+	*prix_ht
+	**decomposition
+	**titre
+
+]
+<B_modes>
+<div class="entry">
+	<BOUCLE_modes(LIVRAISONMODES) {id_livraisonmode IN #ENV{id}|explode{','}} {par num titre,titre}>
+	<strong class="entry-title">
+		[(#LOGO_LIVRAISONMODE|image_reduire{-1})]
+		<span>[(#TITRE)][ (#ENV{decomposition/#ID_LIVRAISONMODE/prix_ttc}|affiche_monnaie)]</span>
+	</strong>
+	[<div class="entry-content">
+		(#DESCRIPTIF)
+	</div>]
+	</BOUCLE_modes>
+	<div class="postmeta p">
+		<button type="submit" class="btn btn-primary" name="choixmode\[#ENV{id}\]" value="#ENV{id}">
+			#SET{prix,#ENV{prix}|affiche_monnaie}
+			<:livraison:bouton_choix_mode{mode=#ENV{titre},prix=#GET{prix}}:>
+		</button>
+	</div>
+</div>
+</B_modes>

--- a/inc/livraison.php
+++ b/inc/livraison.php
@@ -370,9 +370,13 @@ function commande_trouver_livraisons_possibles($id_commande, $pays, $code_postal
  * @param int $id_commande
  * @param int $id_livraisonmode
  *   si pas fourni on reprend celui deja existant pour une mise a jour du cout
+ * @param array $options
+ *   Tableau d'options pour indiquer pays et cp au lieu de prendre ceux dans la commande
+ *   - code_postal
+ *   - code_pays
  * @return bool
  */
-function fixer_livraison_commande($id_commande, $id_livraisonmode=0){
+function fixer_livraison_commande($id_commande, $id_livraisonmode=0, $options){
 	$where = "id_commande=".intval($id_commande)." AND objet=".sql_quote('livraisonmode');
 
 	if (!$id_commande
@@ -380,13 +384,22 @@ function fixer_livraison_commande($id_commande, $id_livraisonmode=0){
 		return false;
 	}
 
-	if ($commande['livraison_nom']) {
-		$pays = $commande['livraison_adresse_pays'];
-		$cp = $commande['livraison_adresse_cp'];
-	}
-	else {
-		$pays = $commande['facturation_adresse_pays'];
-		$cp = $commande['facturation_adresse_cp'];
+	// Soit on a le pays et le code postal dans les options,
+	// soit on les récupère dans la commande
+	if (
+		!isset($options['code_pays'])
+		and !isset($options['code_postal'])
+	) {
+		if ($commande['livraison_nom']) {
+			$pays = $commande['livraison_adresse_pays'];
+			$cp   = $commande['livraison_adresse_cp'];
+		} else {
+			$pays = $commande['facturation_adresse_pays'];
+			$cp   = $commande['facturation_adresse_cp'];
+		}
+	} else {
+		$pays = $options['code_pays'];
+		$cp   = $options['code_postal'];
 	}
 
 	$choix_livraison = commande_trouver_livraisons_possibles($id_commande, $pays, $cp);

--- a/inc/livraison.php
+++ b/inc/livraison.php
@@ -373,7 +373,7 @@ function commande_trouver_livraisons_possibles($id_commande, $pays, $code_postal
  * @param array $options
  *   Tableau d'options pour indiquer pays et cp au lieu de prendre ceux dans la commande
  *   - code_postal
- *   - code_pays
+ *   - pays
  * @return bool
  */
 function fixer_livraison_commande($id_commande, $id_livraisonmode=0, $options){
@@ -387,7 +387,7 @@ function fixer_livraison_commande($id_commande, $id_livraisonmode=0, $options){
 	// Soit on a le pays et le code postal dans les options,
 	// soit on les récupère dans la commande
 	if (
-		!isset($options['code_pays'])
+		!isset($options['pays'])
 		and !isset($options['code_postal'])
 	) {
 		if ($commande['livraison_nom']) {
@@ -398,7 +398,7 @@ function fixer_livraison_commande($id_commande, $id_livraisonmode=0, $options){
 			$cp   = $commande['facturation_adresse_cp'];
 		}
 	} else {
-		$pays = $options['code_pays'];
+		$pays = $options['pays'];
 		$cp   = $options['code_postal'];
 	}
 

--- a/inc/livraison.php
+++ b/inc/livraison.php
@@ -376,7 +376,7 @@ function commande_trouver_livraisons_possibles($id_commande, $pays, $code_postal
  *   - pays
  * @return bool
  */
-function fixer_livraison_commande($id_commande, $id_livraisonmode=0, $options){
+function fixer_livraison_commande($id_commande, $id_livraisonmode=0, $options = array()){
 	$where = "id_commande=".intval($id_commande)." AND objet=".sql_quote('livraisonmode');
 
 	if (!$id_commande


### PR DESCRIPTION
Ce PR ajoute un formulaire alternatif à adresser_commande : c'est une version très simplifiée qui ne propose *que* le choix du mode de livraison. Les traitements, messages d'erreur et cie sont rigoureusement identiques.

C'est un formulaire à utiliser quand on a déjà défini l'adresse de livraison en amont.
Le seul ajout fonctionnel, c'est qu'on ajoute la possibilité de donner le code postal et la ville en option (par défaut ça cherche toujours dans la commande). Ça permet de l'utiliser conjointement avec le plugin coordonnées par exemple.

Le squelette de résumé de modes de livraison est mutualisé entre les 2.

Il y aurait sans doute des choses à rendre plus génériques et à mutualiser pour retrouver les adresses de livraison/facturation d'une commande, mais ça permet déjà un peu plus de souplesse sans trop changer.